### PR TITLE
Integrated prometheus and grafana for monitoring cpu usages during load testing

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -16,7 +16,7 @@ services:
       context: ./single_threaded_epoll
       dockerfile: dockerfile
     ports:
-      - "8004:3000"
+      - "8003:3000"
     networks:
       - appnet
 
@@ -44,6 +44,43 @@ services:
     restart: unless-stopped
     networks:
       - appnet
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    restart: unless-stopped
+    networks:
+      - appnet
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    restart: unless-stopped
+    networks:
+      - appnet
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus-data:
+  grafana-data:
 
 networks:
   appnet:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # - job_name: 'prometheus'
+  #   static_configs:
+  #     - targets: ['localhost:9090']
+
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']

--- a/single_threaded_epoll/client.go
+++ b/single_threaded_epoll/client.go
@@ -88,8 +88,7 @@ func main() {
 	numConnections := 100000
 	queueSize := 1
 
-	addr := "localhost:8004" // TCP server address
-	// addr = "192.168.0.108:8001"
+	addr := "localhost:8003" // TCP server address
 	inputChan := make(chan Request, queueSize)
 	var wg sync.WaitGroup
 	for i := 0; i < numWorker; i++ {


### PR DESCRIPTION
1. Changed port of single threaded epoll from 8004 to 8003 to have some order with other containers

2. Added prometheus and grafana containers.

3. Configured prometheus for scrapping metrics from cAdvisor